### PR TITLE
Refactor internal header/options/get

### DIFF
--- a/lib/trav3.rb
+++ b/lib/trav3.rb
@@ -2040,7 +2040,7 @@ module Trav3
     def without_limit
       limit = opts.remove(:limit)
       result = yield
-      opts.build({limit: limit}) if limit
+      opts.build(limit: limit) if limit
       result
     end
   end

--- a/lib/trav3.rb
+++ b/lib/trav3.rb
@@ -12,8 +12,6 @@ require 'trav3/rest'
 
 # Trav3 project namespace
 module Trav3
-  API_ROOT = 'https://api.travis-ci.org'
-
   # An abstraction for the Travis CI v3 API
   #
   # @author Daniel P. Clark https://6ftdan.com
@@ -24,7 +22,6 @@ module Trav3
   # @!attribute [r] headers
   #   @return [Headers] Request headers object
   class Travis
-    API_ENDPOINT = API_ROOT
     attr_reader :api_endpoint
     attr_reader :options
     attr_reader :headers
@@ -36,7 +33,7 @@ module Trav3
     def initialize(repo)
       validate_repo_format repo
 
-      @api_endpoint = API_ENDPOINT
+      @api_endpoint = 'https://api.travis-ci.org'
       @repo = sanitize_repo_name repo
 
       initial_defaults
@@ -62,7 +59,7 @@ module Trav3
     #   @param value [Symbol, String, Integer] value for key
     # @return [self]
     def defaults(**args)
-      (@options ||= Options.new).build(**args)
+      (@options ||= Options.new).build(args)
       self
     end
 
@@ -75,7 +72,7 @@ module Trav3
     #   @param value [Symbol, String, Integer] value for key
     # @return [self]
     def h(**args)
-      (@headers ||= Headers.new).build(**args)
+      (@headers ||= Headers.new).build(args)
       self
     end
 
@@ -1965,6 +1962,18 @@ module Trav3
       Trav3::REST.get(self, url, raw_reply)
     end
 
+    def get_path(url)
+      get("#{without_repo}#{url}")
+    end
+
+    def get_path_with_opts(url)
+      url, opt = url.match(/(.+)\?(.*)/)&.captures || url
+      opts.immutable do |o|
+        o.send(:update, opt)
+        get_path("#{url}#{opts}")
+      end
+    end
+
     def initial_defaults
       defaults(limit: 25)
       h('Content-Type': 'application/json')
@@ -2031,7 +2040,7 @@ module Trav3
     def without_limit
       limit = opts.remove(:limit)
       result = yield
-      opts.build(limit: limit) if limit
+      opts.build({limit: limit}) if limit
       result
     end
   end

--- a/lib/trav3/headers.rb
+++ b/lib/trav3/headers.rb
@@ -7,11 +7,11 @@ module Trav3
     extend Forwardable
     def_delegators :@heads, :each_pair
 
-    def initialize(**args)
-      build(**args)
+    def initialize(args = {})
+      build(args)
     end
 
-    def build(**args)
+    def build(args = {})
       @heads ||= {}
 
       args.each do |(key, value)|

--- a/lib/trav3/options.rb
+++ b/lib/trav3/options.rb
@@ -96,6 +96,7 @@ module Trav3
 
     def update(other)
       return self unless other
+
       build(parse(other))
     end
   end

--- a/lib/trav3/options.rb
+++ b/lib/trav3/options.rb
@@ -2,8 +2,8 @@
 
 module Trav3
   class Options
-    def initialize(**args)
-      build(**args)
+    def initialize(args = {})
+      build(args)
     end
 
     def opts
@@ -14,7 +14,7 @@ module Trav3
       end
     end
 
-    def build(**args)
+    def build(args = {})
       @opts ||= []
 
       args.each do |(key, value)|
@@ -41,6 +41,13 @@ module Trav3
       result
     end
 
+    def immutable
+      old = @opts
+      result = yield self
+      @opts = old
+      result
+    end
+
     def remove(key)
       return_value = nil
 
@@ -62,7 +69,7 @@ module Trav3
     def +(other)
       raise TypeError, "Options type expected, #{other.class} given" unless other.is_a? Options
 
-      @opts += other.instance_variable_get(:@opts)
+      update other.instance_variable_get(:@opts)
 
       self
     end
@@ -79,6 +86,17 @@ module Trav3
 
     def split
       ->(entry) { entry.split('=') }
+    end
+
+    def parse(other)
+      return other.split('&').map(&split).to_h if other.is_a? String
+
+      other.map(&split).to_h
+    end
+
+    def update(other)
+      return self unless other
+      build(parse(other))
     end
   end
 end

--- a/lib/trav3/pagination.rb
+++ b/lib/trav3/pagination.rb
@@ -31,7 +31,7 @@ module Trav3
     end
 
     def get(path)
-      Trav3::REST.get(travis, "#{travis.api_endpoint}#{path}")
+      travis.send(:get_path, path.to_s)
     end
     private :travis
   end

--- a/lib/trav3/response/response_collection.rb
+++ b/lib/trav3/response/response_collection.rb
@@ -51,7 +51,7 @@ module Trav3
     def follow(idx = nil)
       if href? && !idx
         url = collection.fetch('@href')
-        return travis.send(:get, "#{travis.send(:api_endpoint)}#{url}#{travis.send(:opts)}")
+        return travis.send(:get_path_with_opts, url.to_s)
       end
 
       result = fetch(idx)

--- a/lib/trav3/response/response_collection.rb
+++ b/lib/trav3/response/response_collection.rb
@@ -51,7 +51,7 @@ module Trav3
     def follow(idx = nil)
       if href? && !idx
         url = collection.fetch('@href')
-        return travis.send(:get_path_with_opts, url.to_s)
+        return travis.send(:get_path_with_opts, url)
       end
 
       result = fetch(idx)

--- a/lib/trav3/version.rb
+++ b/lib/trav3/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Trav3
-  VERSION = '0.2.5'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
The private methods `get_path` and `get_path_with_opts` are meant to be
used as internal helpers methods for `follow` and `pagination`.  The
`get_path_with_opts` understands a `@href` follow link may include
options and will toggle those options on only during the request.  Those
options will overide any current ones by the same name which are set.

This update also includes `Options` and `Headers` switching away from
`**kwarg` style since that requires the keys be symbols and for
convenience we need strings to be allowed.