### PR TITLE
Prefer explicit parameter `:delete` for clarity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3789,7 +3789,7 @@ Style/WordArray:
 Style/YodaCondition:
   Description: 'Do not use literals as the first operand of a comparison.'
   Reference: 'https://en.wikipedia.org/wiki/Yoda_conditions'
-  Enabled: true
+  Enabled: false
   EnforcedStyle: forbid_for_all_comparison_operators
   SupportedStyles:
     - forbid_for_all_comparison_operators

--- a/lib/trav3.rb
+++ b/lib/trav3.rb
@@ -1071,7 +1071,7 @@ module Trav3
     # @return [Success, RequestError]
     def caches(delete = false)
       without_limit do
-        delete and return delete("#{with_repo}/caches#{opts}")
+        :delete.==(delete) and return delete("#{with_repo}/caches#{opts}")
         get("#{with_repo}/caches#{opts}")
       end
     end


### PR DESCRIPTION
Allowing any truthy value for a delete action leaves much amibuity for
future developers reading places where the method is used and it doesn't
explicitly say that delete is what the parameter is doing.